### PR TITLE
Added a gate delay parameter.

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -25,7 +25,7 @@
 
 // global
 #define CARBON_VERSION_MAJOR 1
-#define CARBON_VERSION_MINOR 14
+#define CARBON_VERSION_MINOR 15
 #define CARBON_VERSION_MAJMIN ((CARBON_VERSION_MAJOR << 16) | CARBON_VERSION_MINOR)
 
 // memory mapping
@@ -148,6 +148,8 @@
 #define CVPROC_BEND_RANGE_MAX 12  // max setting for CV bend range
 #define CVPROC_CVOFFSET_MIN -450  // min setting for CV offset
 #define CVPROC_CVOFFSET_MAX 450  // max setting for CV offset
+#define CVPROC_CVGATEDELAY_MIN 0 // min setting for CV gate delay
+#define CVPROC_CVGATEDELAY_MAX 64 // max setting for CV gate delay (ticks).
 
 // MIDI clock
 #define MIDI_CLOCK_TASK_INTERVAL_US (SEQ_TASK_INTERVAL_US)

--- a/src/cvproc.h
+++ b/src/cvproc.h
@@ -70,6 +70,9 @@ void cvproc_set_cvcal(int out, int scale);
 // set the offset for an output
 void cvproc_set_cvoffset(int out, int offset);
 
+// set the gate delay for an output
+void cvproc_set_cvgatedelay(int out, int delay);
+
 #endif
 
 

--- a/src/gui/panel_menu.c
+++ b/src/gui/panel_menu.c
@@ -441,6 +441,16 @@ void panel_menu_handle_state_change(int event_type, int *data, int data_len) {
                 pmstate.menu_timeout_count = pmstate.menu_timeout;
             }
             break;
+        case SCE_SONG_CVGATEDELAY:
+            if(pmstate.menu_mode == PANEL_MENU_SYS &&
+                    (pmstate.menu_submode == PANEL_MENU_SYS_CVGATEDELAY1 ||
+                    pmstate.menu_submode == PANEL_MENU_SYS_CVGATEDELAY2 ||
+                    pmstate.menu_submode == PANEL_MENU_SYS_CVGATEDELAY3 ||
+                    pmstate.menu_submode == PANEL_MENU_SYS_CVGATEDELAY4)) {
+                panel_menu_update_display();
+                pmstate.menu_timeout_count = pmstate.menu_timeout;
+            }
+            break;
         case SCE_SONG_STEP_LEN:
             if(pmstate.menu_mode == PANEL_MENU_CLOCK &&
                     pmstate.menu_submode == PANEL_MENU_CLOCK_STEP_LEN) {
@@ -976,6 +986,17 @@ void panel_menu_display_sys(void) {
             sprintf(tempstr, "%d", song_get_cvoffset(temp));
             gui_set_menu_value(tempstr);
             break;
+        case PANEL_MENU_SYS_CVGATEDELAY1:
+        case PANEL_MENU_SYS_CVGATEDELAY2:
+        case PANEL_MENU_SYS_CVGATEDELAY3:
+        case PANEL_MENU_SYS_CVGATEDELAY4:
+            temp = pmstate.menu_submode - PANEL_MENU_SYS_CVGATEDELAY1;
+            gui_set_menu_subtitle("CV Gate Delay");
+            sprintf(tempstr, "Gate Delay %d", (temp + 1));
+            gui_set_menu_param(tempstr);
+            sprintf(tempstr, "%d", song_get_cvgatedelay(temp));
+            gui_set_menu_value(tempstr);
+            break;
         case PANEL_MENU_SYS_MENU_TIMEOUT:
             gui_set_menu_subtitle("Menu Timeout");
             gui_set_menu_param("Timeout");
@@ -1257,6 +1278,13 @@ void panel_menu_edit_sys(int change) {
         case PANEL_MENU_SYS_CVOFFSET4:
             temp = pmstate.menu_submode - PANEL_MENU_SYS_CVOFFSET1;
             seq_ctrl_adjust_cvoffset(temp, change);
+            break;
+        case PANEL_MENU_SYS_CVGATEDELAY1:
+        case PANEL_MENU_SYS_CVGATEDELAY2:
+        case PANEL_MENU_SYS_CVGATEDELAY3:
+        case PANEL_MENU_SYS_CVGATEDELAY4:
+            temp = pmstate.menu_submode - PANEL_MENU_SYS_CVGATEDELAY1;
+            seq_ctrl_adjust_cvgatedelay(temp, change);
             break;
         case PANEL_MENU_SYS_MENU_TIMEOUT:
             panel_menu_set_timeout(seq_utils_clamp(pmstate.menu_timeout +

--- a/src/gui/panel_menu.h
+++ b/src/gui/panel_menu.h
@@ -81,7 +81,7 @@
 #define PANEL_MENU_MIDI_REMOTE_CTRL 8  // per song
 #define PANEL_MENU_MIDI_AUTOLIVE 9  // per song
 // sys
-#define PANEL_MENU_SYS_NUM_SUBMODES 20
+#define PANEL_MENU_SYS_NUM_SUBMODES 24
 #define PANEL_MENU_SYS_VERSION 0  // global
 #define PANEL_MENU_SYS_CVGATE_PAIRS 1  // per song
 #define PANEL_MENU_SYS_CV_BEND_RANGE 2  // per song
@@ -101,7 +101,11 @@
 #define PANEL_MENU_SYS_CVOFFSET2 16  // per song
 #define PANEL_MENU_SYS_CVOFFSET3 17  // per song
 #define PANEL_MENU_SYS_CVOFFSET4 18  // per song
-#define PANEL_MENU_SYS_MENU_TIMEOUT 19 // global
+#define PANEL_MENU_SYS_CVGATEDELAY1 19  // per song
+#define PANEL_MENU_SYS_CVGATEDELAY2 20  // per song
+#define PANEL_MENU_SYS_CVGATEDELAY3 21  // per song
+#define PANEL_MENU_SYS_CVGATEDELAY4 22  // per song
+#define PANEL_MENU_SYS_MENU_TIMEOUT 23 // global
 // clock
 #define PANEL_MENU_CLOCK_NUM_SUBMODES 10
 #define PANEL_MENU_CLOCK_STEP_LEN 0  // per scene / track

--- a/src/seq/seq_ctrl.c
+++ b/src/seq/seq_ctrl.c
@@ -226,6 +226,9 @@ void seq_ctrl_handle_state_change(int event_type, int *data, int data_len) {
         case SCE_SONG_CVOFFSET:
             cvproc_set_cvoffset(data[0], data[1]);
             break;
+        case SCE_SONG_CVGATEDELAY:
+            cvproc_set_cvgatedelay(data[0], data[1]);
+            break;
         case SCE_CONFIG_LOADED:
 //            log_debug("scrt - config loaded");
             gui_startup();  // start the GUI now that we know which LCD type we have
@@ -557,6 +560,16 @@ void seq_ctrl_adjust_cvoffset(int channel, int change) {
     }
     song_set_cvoffset(channel, seq_utils_clamp(song_get_cvoffset(channel) + change,
         CVPROC_CVOFFSET_MIN, CVPROC_CVOFFSET_MAX));
+}
+
+// adjust the CV gate delay on a channel
+void seq_ctrl_adjust_cvgatedelay(int channel, int change) {
+    if(channel < 0 || channel >= CVPROC_NUM_OUTPUTS) {
+        log_error("scacgd - channel invalid: %d", channel);
+        return;
+    }
+    song_set_cvgatedelay(channel, seq_utils_clamp(song_get_cvgatedelay(channel) + change,
+        CVPROC_CVGATEDELAY_MIN, CVPROC_CVGATEDELAY_MAX));
 }
 
 // set the tempo
@@ -1455,6 +1468,13 @@ void seq_ctrl_refresh_modules(void) {
         song_set_magic_range(12);
         song_set_magic_chance(100);
     }
+    // song version <= 1.14
+    if (song_ver <= 0x0001000e) {
+        song_set_cvgatedelay(0, 0);
+        song_set_cvgatedelay(1, 0);
+        song_set_cvgatedelay(2, 0);
+        song_set_cvgatedelay(3, 0);
+    }
 
     // make sure we save back the current version
     if(song_ver != CARBON_VERSION_MAJMIN) {
@@ -1478,6 +1498,9 @@ void seq_ctrl_refresh_modules(void) {
     for(i = 0; i < CVPROC_NUM_OUTPUTS; i ++) {
         cvproc_set_cvcal(i, song_get_cvcal(i));
         cvproc_set_cvoffset(i, song_get_cvoffset(i));
+    }
+    for(i = 0; i < CVPROC_NUM_OUTPUTS; i ++) {
+        cvproc_set_cvgatedelay(i, song_get_cvgatedelay(i));
     }
 }
 

--- a/src/seq/seq_ctrl.h
+++ b/src/seq/seq_ctrl.h
@@ -142,6 +142,9 @@ void seq_ctrl_adjust_cvcal(int channel, int change);
 // adjust the CV offset on a channel
 void seq_ctrl_adjust_cvoffset(int channel, int change);
 
+// adjust the CV gate delay on a channel
+void seq_ctrl_adjust_cvgatedelay(int channel, int change);
+
 // set the tempo
 void seq_ctrl_set_tempo(float tempo);
 

--- a/src/seq/song.h
+++ b/src/seq/song.h
@@ -201,6 +201,12 @@ int song_get_cvoffset(int out);
 // set the CV offset for an output
 void song_set_cvoffset(int out, int offset);
 
+// get the CV gate delay for an output
+int song_get_cvgatedelay(int out);
+
+// set the CV gate delay for an output
+void song_set_cvgatedelay(int out, int delay);
+
 // get a MIDI port clock out enable setting - returns -1 on error
 // port must be a MIDI output port
 int song_get_midi_port_clock_out(int port);

--- a/src/util/state_change_events.h
+++ b/src/util/state_change_events.h
@@ -51,6 +51,7 @@ enum STATE_CHANGE_EVENT {
     SCE_SONG_CV_OUTPUT_SCALING,  // arg0 = CV output, arg1 = mode
     SCE_SONG_CVCAL,  // arg0 = channel, arg1 = cal
     SCE_SONG_CVOFFSET,  // arg0 = channel, arg1 = offset
+    SCE_SONG_CVGATEDELAY, // arg0 = channel, arg1 = delay
     SCE_SONG_MIDI_PORT_CLOCK_OUT,  // arg0 = port, arg1 = ppq
     SCE_SONG_MIDI_CLOCK_SOURCE,  // arg0 = source
     SCE_SONG_MIDI_REMOTE_CTRL,  // arg0 = enable


### PR DESCRIPTION
This parameter is set for each individual CV output and controls how many ticks the GATE_ON message is delayed by. In particular, this fixes issues when connecting CARBON to the Moog DFAM (CV -> velocity, GATE -> trigger). It seems as though the DFAM is either very intolerant to timing discrepancies between the velocity + trigger inputs, or that the DFAM itself is delayed in recognizing voltage changes to the velocity input. In either case, delaying the CARBON GATE ON message by about 3-4 ticks fixes the problem.

This parameter is saved with the song data and thus required an increment to the CARBON version (1.15 now). I've only done basic testing with a simple track using ABCD cv pairing. It would be interesting to see how this holds up in a polyphonic scenario, or even LIVE mode (which I haven't even used yet).