### PR TITLE
copy and paste steps in step edit mode

### DIFF
--- a/src/gui/panel.c
+++ b/src/gui/panel.c
@@ -670,11 +670,19 @@ void panel_handle_seq_input(int ctrl, int val) {
                 panel_handle_shift_double_tap();  // handle canceling of modes
                 break;
             case PANEL_SW_SONG_MODE:
-                seq_ctrl_toggle_song_mode();
+                if (panel_get_edit_mode() == PANEL_EDIT_MODE_STEP) {
+                    if (pstate.shift_state == 1) {
+                        step_edit_mark_step_for_copying();
+                    } else {
+                        step_edit_copy_marked_step();
+                    }
+                } else {
+                    seq_ctrl_toggle_song_mode();
 #ifdef GFX_REMLCD_MODE
                 // allow screen to be redrawn for client
-                gui_force_refresh();
+                    gui_force_refresh();
 #endif
+                }
                 break;
             case PANEL_ENC_SPEED:
                 switch(panel_get_edit_mode()) {

--- a/src/gui/step_edit.h
+++ b/src/gui/step_edit.h
@@ -68,5 +68,11 @@ void step_edit_adjust_ratchet_mode(int change, int shift);
 // clear the current step
 void step_edit_clear_step(void);
 
+// store the current track and step_pos 
+void step_edit_mark_step_for_copying(void);
+
+// copy the event from copy_from_scene, copy_from_track, copy_from_pos
+void step_edit_copy_marked_step(void);
+
 #endif
 


### PR DESCRIPTION
I use carbon a lot for my guitar pedals, but editing the CCs via step edit mode is cumbersome, as I must enter for each step the CC number(s) again. So I have added a copy & paste feature.
As long as Step Mode is active, the Song Mode button is utilized for this feature (instead of activate the Song Mode). Shift-Song Mode marks the current track and step, and Song Mode will copy the events from this marked track/step to the current track/step. So I must enter only the CC numbers in one step, press Shift-Song Mode, select a new step, copy it with Song Mode and must only edit the values. Of course this can be also used to copy notes.